### PR TITLE
Prefer AWS credentials profile name to literal keys

### DIFF
--- a/src/SleetLib/Commands/CreateConfigCommand.cs
+++ b/src/SleetLib/Commands/CreateConfigCommand.cs
@@ -74,8 +74,7 @@ namespace Sleet
                         { "type", "s3" },
                         { "bucketName", "bucketname" },
                         { "region", "us-east-1" },
-                        { "accessKeyId", "" },
-                        { "secretAccessKey", "" }
+                        { "profileName", "default" }
                     };
                     break;
             }


### PR DESCRIPTION
The AWS SDK for .Net allows credentials to be loaded from "profiles" stored in shared files rather than being provided directly in code. This change removes the entries for keys added to `sleet.json` by the `CreateConfigCommand` and add one for entering an AWS profile name. It also changed the `AmazonS3Client` constructor used in `FileSystemFactory` to make use of the provided profile.  This is not a breaking change since keys provided in existing `sleet.json` files will be preferred to profile names.